### PR TITLE
Filter issue list by category

### DIFF
--- a/devdesk/package.json
+++ b/devdesk/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^7.1.2",
     "axios": "^0.19.2",
     "node-sass": "^4.13.1",
+    "qs": "^6.9.1",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
     "react-redux": "^7.2.0",

--- a/devdesk/src/Components/IssueList.js
+++ b/devdesk/src/Components/IssueList.js
@@ -6,11 +6,17 @@ import { getData } from "../actions";
 import { connect } from "react-redux";
 import { Switch, Route, Link as RouterLink } from "react-router-dom";
 import { axiosWithAuth } from "../utils/axiosWithAuth";
+import qs from "qs";
 
 function IssueList(props) {
   const { match } = props;
   const issues = props.issues || null;
   const [categories, setCategories] = useState(null);
+  const [filtered, setFiltered] = useState(issues);
+
+  const queryParams = qs.parse(props.location.search, {
+    ignoreQueryPrefix: true
+  });
 
   // Using axios outside of redux so that I can meet MVP for using
   // useEffect and whatnot. --LeRoyce
@@ -21,6 +27,17 @@ function IssueList(props) {
       .catch(err => console.log("Failed to retrieve categories: ", err));
   }, []);
 
+  useEffect(() => {
+    if (issues !== null && queryParams.category !== undefined) {
+      const newFiltered = issues.filter(x =>
+        x.category.toLowerCase().includes(queryParams.category.toLowerCase())
+      );
+      setFiltered(newFiltered);
+    } else {
+      setFiltered(issues);
+    }
+  }, [issues, queryParams.category]);
+
   return (
     <Container>
       <button onClick={props.getData}>Refresh Issue List</button>
@@ -30,8 +47,8 @@ function IssueList(props) {
       <Categories categories={categories} match={match} />
       <Switch>
         <Route exact path={`${match.path}`}>
-          {issues !== null ? (
-            issues.map(issue => <IssueCard key={issue.id} {...issue} />)
+          {filtered !== null ? (
+            filtered.map(issue => <IssueCard key={issue.id} {...issue} />)
           ) : (
             <p>Loading...</p>
           )}

--- a/devdesk/src/Components/IssueList.js
+++ b/devdesk/src/Components/IssueList.js
@@ -1,26 +1,40 @@
-import React from "react";
-import { Container } from "@material-ui/core";
+import React, { useEffect, useState } from "react";
+import { Container, Link, Grid, Paper } from "@material-ui/core";
 import IssueCard from "./IssueCard";
 import Issue from "./Issue";
-import { Switch, Route, Link } from "react-router-dom";
-import { getData } from "../actions"
-import { connect } from 'react-redux';
+import { getData } from "../actions";
+import { connect } from "react-redux";
+import { Switch, Route, Link as RouterLink } from "react-router-dom";
+import { axiosWithAuth } from "../utils/axiosWithAuth";
 
 function IssueList(props) {
   const { match } = props;
   const issues = props.issues || null;
+  const [categories, setCategories] = useState(null);
+
+  // Using axios outside of redux so that I can meet MVP for using
+  // useEffect and whatnot. --LeRoyce
+  useEffect(() => {
+    axiosWithAuth()
+      .get("/api/categories")
+      .then(res => setCategories(res.data))
+      .catch(err => console.log("Failed to retrieve categories: ", err));
+  }, []);
 
   return (
     <Container>
       <button onClick={props.getData}>Refresh Issue List</button>
-      <Link to="/createIssue">Create New Issue</Link>
+      <Link component={RouterLink} to="/createIssue">
+        Create New Issue
+      </Link>
+      <Categories categories={categories} match={match} />
       <Switch>
         <Route exact path={`${match.path}`}>
           {issues !== null ? (
             issues.map(issue => <IssueCard key={issue.id} {...issue} />)
           ) : (
-              <p>Loading...</p>
-            )}
+            <p>Loading...</p>
+          )}
         </Route>
         <Route
           path={`${match.path}/:id`}
@@ -34,9 +48,28 @@ function IssueList(props) {
 const mapStateToProps = state => {
   return {
     issues: state.data
+  };
+};
+
+export default connect(mapStateToProps, { getData })(IssueList);
+
+function Categories(props) {
+  if (props.categories !== null) {
+    return (
+      <Grid container justify="center">
+        {props.categories.map((category, idx) => (
+          <Paper key={idx}>
+            <Link
+              component={RouterLink}
+              to={`${props.match.url}?category=${category}`}
+            >
+              {category}
+            </Link>
+          </Paper>
+        ))}
+      </Grid>
+    );
+  } else {
+    return <div></div>;
   }
 }
-
-export default connect(mapStateToProps, { getData })(IssueList)
-
-

--- a/devdesk/yarn.lock
+++ b/devdesk/yarn.lock
@@ -8689,6 +8689,11 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@^6.9.1:
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.1.tgz#20082c65cb78223635ab1a9eaca8875a29bf8ec9"
+  integrity sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==
+
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"


### PR DESCRIPTION
The issue list can now be filtered using the `?category=<some-category>` query parameter. There is also a list of the categories (provided by the `/api/categories` endpoint) that the user can click on at the top of the issue list. 